### PR TITLE
Add optional parameter to fetch response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ and max number of retries
     * [.getAllWebhookRegistrations(consumerOrgId, integrationId)](#EventsCoreAPI+getAllWebhookRegistrations) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.deleteWebhookRegistration(consumerOrgId, integrationId, registrationId)](#EventsCoreAPI+deleteWebhookRegistration) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.publishEvent(cloudEvent)](#EventsCoreAPI+publishEvent) ⇒ <code>Promise.&lt;string&gt;</code>
-    * [.getEventsFromJournal(journalUrl, [eventsJournalOptions])](#EventsCoreAPI+getEventsFromJournal) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.getEventsFromJournal(journalUrl, [eventsJournalOptions], [fetchResponseHeaders])](#EventsCoreAPI+getEventsFromJournal) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.getEventsObservableFromJournal(journalUrl, [eventsJournalOptions], [eventsJournalPollingOptions])](#EventsCoreAPI+getEventsObservableFromJournal) ⇒ <code>Observable</code>
     * [.verifySignatureForEvent(event, clientSecret, signatureHeaderValue)](#EventsCoreAPI+verifySignatureForEvent) ⇒ <code>boolean</code>
 
@@ -422,7 +422,7 @@ If retries are set, publish events are retried on network issues, 5xx and 429 er
 
 <a name="EventsCoreAPI+getEventsFromJournal"></a>
 
-### eventsCoreAPI.getEventsFromJournal(journalUrl, [eventsJournalOptions]) ⇒ <code>Promise.&lt;object&gt;</code>
+### eventsCoreAPI.getEventsFromJournal(journalUrl, [eventsJournalOptions], [fetchResponseHeaders]) ⇒ <code>Promise.&lt;object&gt;</code>
 Get events from a journal.
 
 **Kind**: instance method of [<code>EventsCoreAPI</code>](#EventsCoreAPI)  
@@ -432,6 +432,7 @@ Get events from a journal.
 | --- | --- | --- |
 | journalUrl | <code>string</code> | URL of the journal or 'next' link to read from (required) |
 | [eventsJournalOptions] | [<code>EventsJournalOptions</code>](#EventsJournalOptions) | Query options to send with the URL |
+| [fetchResponseHeaders] | <code>boolean</code> | Set this to true if you want to fetch the complete response headers |
 
 <a name="EventsCoreAPI+getEventsObservableFromJournal"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -422,9 +422,10 @@ class EventsCoreAPI {
    *
    * @param {string} journalUrl URL of the journal or 'next' link to read from (required)
    * @param {EventsJournalOptions} [eventsJournalOptions] Query options to send with the URL
+   * @param {boolean} [fetchResponseHeaders] Set this to true if you want to fetch the complete response headers
    * @returns {Promise<object>} with the response json includes events and links (if available)
    */
-  async getEventsFromJournal (journalUrl, eventsJournalOptions) {
+  async getEventsFromJournal (journalUrl, eventsJournalOptions, fetchResponseHeaders) {
     const url = appendQueryParams(journalUrl, eventsJournalOptions)
     const headers = {}
     const requestOptions = this.__createRequest('GET', headers)
@@ -441,6 +442,9 @@ class EventsCoreAPI {
       }
       if (retryAfterHeader) {
         result.retryAfter = parseRetryAfterHeader(retryAfterHeader)
+      }
+      if (fetchResponseHeaders) {
+        result.responseHeaders = response.headers.raw()
       }
       return new Promise((resolve, reject) => {
         resolve(result)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -527,6 +527,14 @@ describe('Fetch from journalling', () => {
     expect(retryOnSpy).toHaveBeenCalledWith(3)
     retryOnSpy.mockRestore()
   })
+  it('200 response on fetch from journal with response headers', async () => {
+    const sdkClient = await createSdkClient()
+    mockExponentialBackoff(mock.data.journalResponseBody, mock.data.journalResponseHeader200)
+    const res = await sdkClient.getEventsFromJournal(journalUrl, {}, true)
+    expect(res.link.next).toBe('http://journal-url/events-fast/organizations/orgId/integrations/integId/regId?since=position-1')
+    expect(res.events[0].position).toBe('position-2')
+    expect(res.responseHeaders).toBeDefined()
+  })
 })
 
 describe('Get events observable from journal', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -475,6 +475,7 @@ describe('Fetch from journalling', () => {
     const res1 = await sdkClient.getEventsFromJournal(journalUrl)
     expect(res1.link.next).toBe('http://journal-url/events-fast/organizations/orgId/integrations/integId/regId?since=position-1')
     expect(res1.events[0].position).toBe('position-2')
+    expect(res1.responseHeaders).toBeUndefined()
   })
   it('204 response on fetch from journal with retry after as number', async () => {
     const sdkClient = await createSdkClient()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an optional parameter `fetchResponseHeaders` to `getEventsFromJournal`. When this parameter is set to true, the result contains the complete response headers in `result.responseHeaders`.

Example:

```
{
  "access-control-allow-credentials": [
    "true"
  ],
  "access-control-allow-headers": [
    "X-Requested-With, Content-Type, Authorization, x-api-key, x-request-id"
  ],
  "access-control-allow-methods": [
    "GET, POST, PUT, DELETE, OPTIONS, PATCH"
  ],
  "access-control-allow-origin": [
    "*"
  ],
  "access-control-max-age": [
    "60"
  ],
  "connection": [
    "close"
  ],
  "date": [
    "Wed, 14 Jul 2021 00:31:27 GMT"
  ],
  "link": [
    "</events/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569>; rel=\"events\", </events-fast/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569?since=rabbit:e458d64e-a9c9-4c3c-87f7-fd39a2767dc8.penguin:f5544d7b-8bd5-4adf-a3a3-b4c177c46673.ce5880d7-0c45-4fa9-86b4-d64c778361b1.0.1625710722.vjpw1rd0pbvmp38-mevw>; rel=\"next\", </count/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569?since=rabbit:e458d64e-a9c9-4c3c-87f7-fd39a2767dc8.penguin:f5544d7b-8bd5-4adf-a3a3-b4c177c46673.ce5880d7-0c45-4fa9-86b4-d64c778361b1.0.1625710722.vjpw1rd0pbvmp38-mevw>; rel=\"count\", </events/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569?latest=true>; rel=\"latest\", </events/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569?since={position}&limit={count}>; rel=\"page\", </events/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569?seek={duration}&limit={count}>; rel=\"seek\", </events-validate/organizations/52381/integrations/183697/5103d8b7-9cbb-4404-97b3-fbe48617a569?since=rabbit:e458d64e-a9c9-4c3c-87f7-fd39a2767dc8.penguin:f5544d7b-8bd5-4adf-a3a3-b4c177c46673.ce5880d7-0c45-4fa9-86b4-d64c778361b1.0.1625710722.vjpw1rd0pbvmp38-mevw>; rel=\"validate\""
  ],
  "retry-after": [
    "10"
  ],
  "server": [
    "openresty"
  ],
  "x-request-id": [
    "MCwsTLWLs5E9WPzFCEkovbRiEWxs1YgL"
  ]
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/CI-4613

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It is useful to have the complete response headers when browsing events from Journaling. These response headers are available when using the Journaling API.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Passed all existing unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
