### PR TITLE
Events Base URL and Ingress URL were not set using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ Returns a Promise that resolves with a new EventsCoreAPI object.
 | --- | --- | --- |
 | [timeout] | <code>number</code> | Http request timeout in ms (optional) |
 | [retries] | <code>number</code> | Number of retries in case of 5xx errors. Default 0 (optional) |
+| [eventsBaseURL] | <code>string</code> | Base URL for Events Default https://api.adobe.io (optional) |
+| [eventsIngressURL] | <code>string</code> | Ingress URL for Events. Default https://eventsingress.adobe.io (optional) |
 
 <a name="EventsJournalOptions"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,12 +28,12 @@ const Base64 = require('crypto-js/enc-base64')
 
 const EventsConsumerFromJournal = require('./journalling')
 
-const EVENTS_BASE_URL = process.env.EVENTS_BASE_URL || 'https://api.adobe.io'
-const EVENTS_INGRESS_URL = process.env.EVENTS_INGRESS_URL || 'https://eventsingress.adobe.io'
 /**
  * @typedef {object} EventsCoreAPIOptions
  * @property {number} [timeout] Http request timeout in ms (optional)
  * @property {number} [retries] Number of retries in case of 5xx errors. Default 0 (optional)
+ * @property {string} [eventsBaseURL] Base URL for Events Default https://api.adobe.io (optional)
+ * @property {string} [eventsIngressURL] Ingress URL for Events. Default https://eventsingress.adobe.io (optional)
  */
 /**
  * Returns a Promise that resolves with a new EventsCoreAPI object.
@@ -100,6 +100,9 @@ class EventsCoreAPI {
     this.apiKey = apiKey
     /** The JWT Token for the integration with IO Management API scope */
     this.accessToken = accessToken
+    /** Initialise base and Ingress URLs */
+    this.__initLibURLs()
+
     return this
   }
 
@@ -389,7 +392,7 @@ class EventsCoreAPI {
     headers['Content-Type'] = 'application/cloudevents+json'
     const requestOptions = this.__createRequest('POST', headers, JSON.stringify(cloudEvent))
     const retries = (this.httpOptions && this.httpOptions.retries) || 0
-    const url = EVENTS_INGRESS_URL
+    const url = this.httpOptions.eventsIngressURL
     const sdkDetails = { requestOptions: requestOptions, url: url }
     return new Promise((resolve, reject) => {
       fetchRetryClient.exponentialBackoff(url, requestOptions, { maxRetries: retries, initialDelayInMillis: 1000 }, this.__getRetryOn(retries))
@@ -634,7 +637,13 @@ class EventsCoreAPI {
   }
 
   __getUrl (path) {
-    return EVENTS_BASE_URL + path
+    return this.httpOptions.eventsBaseURL + path
+  }
+
+  __initLibURLs () {
+    this.httpOptions = this.httpOptions || {}
+    this.httpOptions.eventsBaseURL = this.httpOptions.eventsBaseURL || 'https://api.adobe.io'
+    this.httpOptions.eventsIngressURL = this.httpOptions.eventsIngressURL || 'https://eventsingress.adobe.io'
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,8 @@ const gOrganizationId = 'test-org'
 const gApiKey = 'test-apikey'
 const gAccessToken = 'test-token'
 const journalUrl = 'http://journal-url/events/organizations/orgId/integrations/integId/regId'
+const EVENTS_BASE_URL = 'fakebaseurl'
+const EVENTS_INGRESS_URL = 'fakeingressurl'
 
 // /////////////////////////////////////////////
 
@@ -51,6 +53,18 @@ beforeEach(() => {
 
 describe('SDK init test', () => {
   it('sdk init test', async () => {
+    const options = {
+      eventsBaseURL: EVENTS_BASE_URL,
+      eventsIngressURL: EVENTS_INGRESS_URL
+    }
+    const sdkClient = await sdk.init(gOrganizationId, gApiKey, gAccessToken, options)
+    expect(sdkClient.organizationId).toBe(gOrganizationId)
+    expect(sdkClient.apiKey).toBe(gApiKey)
+    expect(sdkClient.accessToken).toBe(gAccessToken)
+    expect(sdkClient.httpOptions.eventsBaseURL).toBe(EVENTS_BASE_URL)
+    expect(sdkClient.httpOptions.eventsIngressURL).toBe(EVENTS_INGRESS_URL)
+  })
+  it('sdk init test with URL options', async () => {
     const sdkClient = await createSdkClient()
     expect(sdkClient.organizationId).toBe(gOrganizationId)
     expect(sdkClient.apiKey).toBe(gApiKey)


### PR DESCRIPTION
Events Base URL and Ingress URL were read from process.env at file start. 
When lib was imported in user code these vales would get initialised. 
This meant that any attempt to set process.env var for above would not be picked up by lib, if it was set after lib import.

A better way is to allow these settings is via httpOptions at lib init and let user specify them in constructor params rather than process.env var (which itself is tricky to set for runtime actions)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Developers cannot set EVENTS_BASE_URL and EVENTS_INGRESS_URL using process.end vars because of the problem mentioned above.

## How Has This Been Tested?

manual and unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
