### PR TITLE
env as httpOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ and max number of retries
     * [.organizationId](#EventsCoreAPI+organizationId)
     * [.apiKey](#EventsCoreAPI+apiKey)
     * [.accessToken](#EventsCoreAPI+accessToken)
-    * [.init(organizationId, apiKey, accessToken, [httpOptions])](#EventsCoreAPI+init) ⇒ [<code>Promise.&lt;EventsCoreAPI&gt;</code>](#EventsCoreAPI)
+    * [.init(organizationId, apiKey, accessToken, env, [httpOptions])](#EventsCoreAPI+init) ⇒ [<code>Promise.&lt;EventsCoreAPI&gt;</code>](#EventsCoreAPI)
     * [.getAllProviders(consumerOrgId, providerOptions)](#EventsCoreAPI+getAllProviders) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.getProvider(providerId, [fetchEventMetadata])](#EventsCoreAPI+getProvider) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.createProvider(consumerOrgId, projectId, workspaceId, body)](#EventsCoreAPI+createProvider) ⇒ <code>Promise.&lt;object&gt;</code>
@@ -193,7 +193,7 @@ The JWT Token for the integration with IO Management API scope
 **Kind**: instance property of [<code>EventsCoreAPI</code>](#EventsCoreAPI)  
 <a name="EventsCoreAPI+init"></a>
 
-### eventsCoreAPI.init(organizationId, apiKey, accessToken, [httpOptions]) ⇒ [<code>Promise.&lt;EventsCoreAPI&gt;</code>](#EventsCoreAPI)
+### eventsCoreAPI.init(organizationId, apiKey, accessToken, env, [httpOptions]) ⇒ [<code>Promise.&lt;EventsCoreAPI&gt;</code>](#EventsCoreAPI)
 Initialize SDK.
 
 **Kind**: instance method of [<code>EventsCoreAPI</code>](#EventsCoreAPI)  
@@ -204,6 +204,7 @@ Initialize SDK.
 | organizationId | <code>string</code> | The organization id from your integration |
 | apiKey | <code>string</code> | The api key from your integration |
 | accessToken | <code>string</code> | JWT Token for the integration with IO Management API scope |
+| env | <code>string</code> | the CLI environment |
 | [httpOptions] | [<code>EventsCoreAPIOptions</code>](#EventsCoreAPIOptions) | Options to configure API calls |
 
 <a name="EventsCoreAPI+getAllProviders"></a>
@@ -546,8 +547,9 @@ Returns a Promise that resolves with a new EventsCoreAPI object.
 | --- | --- | --- |
 | [timeout] | <code>number</code> | Http request timeout in ms (optional) |
 | [retries] | <code>number</code> | Number of retries in case of 5xx errors. Default 0 (optional) |
-| [eventsBaseURL] | <code>string</code> | Base URL for Events Default https://api.adobe.io (optional) |
-| [eventsIngressURL] | <code>string</code> | Ingress URL for Events. Default https://eventsingress.adobe.io (optional) |
+| [env] | <code>string</code> | Environment to reconfigure events URLs. Values stage or prod. Default prod (optional) |
+| [eventsBaseURL] | <code>string</code> | Base URL for Events. Has precedence over env option. Default https://api.adobe.io (optional) |
+| [eventsIngressURL] | <code>string</code> | Ingress URL for Events.  Has precedence over env option. Default https://eventsingress.adobe.io (optional) |
 
 <a name="ProviderFilterOptions"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,9 @@ const APPLICATION_HAL_JSON = 'application/hal+json'
  * @typedef {object} EventsCoreAPIOptions
  * @property {number} [timeout] Http request timeout in ms (optional)
  * @property {number} [retries] Number of retries in case of 5xx errors. Default 0 (optional)
- * @property {string} [eventsBaseURL] Base URL for Events Default https://api.adobe.io (optional)
- * @property {string} [eventsIngressURL] Ingress URL for Events. Default https://eventsingress.adobe.io (optional)
+ * @property {string} [env] Environment to reconfigure events URLs. Values stage or prod. Default prod (optional)
+ * @property {string} [eventsBaseURL] Base URL for Events. Has precedence over env option. Default https://api.adobe.io (optional)
+ * @property {string} [eventsIngressURL] Ingress URL for Events.  Has precedence over env option. Default https://eventsingress.adobe.io (optional)
  */
 /**
  * Returns a Promise that resolves with a new EventsCoreAPI object.
@@ -771,12 +772,9 @@ class EventsCoreAPI {
 
   __initLibURLs (env) {
     this.httpOptions = this.httpOptions || {}
-    let eventsBaseUrl = EVENTS_BASE_URL[env]
-    if (!eventsBaseUrl) {
-      eventsBaseUrl = EVENTS_BASE_URL[DEFAULT_ENV]
-      env = DEFAULT_ENV
-    }
-    const eventsIngressUrl = EVENTS_INGRESS_URL[env]
+    const effectiveEnv = env || this.httpOptions.env || DEFAULT_ENV
+    const eventsBaseUrl = EVENTS_BASE_URL[effectiveEnv]
+    const eventsIngressUrl = EVENTS_INGRESS_URL[effectiveEnv]
     this.httpOptions.eventsBaseURL = this.httpOptions.eventsBaseURL || eventsBaseUrl
     this.httpOptions.eventsIngressURL = this.httpOptions.eventsIngressURL || eventsIngressUrl
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,6 +114,15 @@ describe('SDK init test', () => {
     expect(sdkClient.httpOptions.eventsBaseURL).toBe(EVENTS_BASE_URL)
     expect(sdkClient.httpOptions.eventsIngressURL).toBe(EVENTS_INGRESS_URL)
   })
+  it('sdk init test with stage env in httpOptions', async () => {
+    getCliEnv.mockReturnValue(undefined)
+    const sdkClient = await sdk.init(gOrganizationId, gApiKey, gAccessToken, { env: 'stage' })
+    expect(sdkClient.organizationId).toBe(gOrganizationId)
+    expect(sdkClient.apiKey).toBe(gApiKey)
+    expect(sdkClient.accessToken).toBe(gAccessToken)
+    expect(sdkClient.httpOptions.eventsBaseURL).toBe(EVENTS_BASE_URL_STAGE)
+    expect(sdkClient.httpOptions.eventsIngressURL).toBe(EVENTS_INGRESS_URL_STAGE)
+  })
   it('sdk init test - no imsOrgId', async () => {
     return expect(sdk.init(null, gApiKey, gAccessToken)).rejects.toEqual(
       new errorSDK.codes.ERROR_SDK_INITIALIZATION({ messageValues: 'organizationId' })

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,12 +1,14 @@
 /**
  * @property [timeout] - Http request timeout in ms (optional)
  * @property [retries] - Number of retries in case of 5xx errors. Default 0 (optional)
- * @property [eventsBaseURL] - Base URL for Events Default https://api.adobe.io (optional)
- * @property [eventsIngressURL] - Ingress URL for Events. Default https://eventsingress.adobe.io (optional)
+ * @property [env] - Environment to reconfigure events URLs. Values stage or prod. Default prod (optional)
+ * @property [eventsBaseURL] - Base URL for Events. Has precedence over env option. Default https://api.adobe.io (optional)
+ * @property [eventsIngressURL] - Ingress URL for Events.  Has precedence over env option. Default https://eventsingress.adobe.io (optional)
  */
 declare type EventsCoreAPIOptions = {
     timeout?: number;
     retries?: number;
+    env?: string;
     eventsBaseURL?: string;
     eventsIngressURL?: string;
 };
@@ -33,10 +35,11 @@ declare class EventsCoreAPI {
      * @param organizationId - The organization id from your integration
      * @param apiKey - The api key from your integration
      * @param accessToken - JWT Token for the integration with IO Management API scope
+     * @param env - the CLI environment
      * @param [httpOptions] - Options to configure API calls
      * @returns returns object of the class EventsCoreAPI
      */
-    init(organizationId: string, apiKey: string, accessToken: string, httpOptions?: EventsCoreAPIOptions): Promise<EventsCoreAPI>;
+    init(organizationId: string, apiKey: string, accessToken: string, env: string, httpOptions?: EventsCoreAPIOptions): Promise<EventsCoreAPI>;
     /**
      * Http options {retries, timeout}
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows to reconfigure the events URLs to point to stage by exposing a new `httpOption` called `env`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In Adobe Commerce we have appbuilder apps connected to stage environment in the developer console. Current implementation based on cliEnv forces us to hardcode the events URLs in our code base and pass them as `httpOption`. 
Code snippet:
```js
const eventsApi = Events.init("orgId", "apiKey", "accessToken", {
    eventsBaseURL: 'https://api-stage.adobe.io/',
    eventsIngressURL: 'https://eventsingress-stage.adobe.io/',
})
```

This change allows to reconfigure the URLs without the need of hardcoding them.
```js
const eventsApi = Events.init("orgId", "apiKey", "accessToken", { env: 'stage' })
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
