### PR TITLE
[Prism] docs: replace https://rxjs-dev.firebaseapp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,10 +493,10 @@ Get events from a journal.
 <a name="EventsCoreAPI+getEventsObservableFromJournal"></a>
 
 ### eventsCoreAPI.getEventsObservableFromJournal(journalUrl, [eventsJournalOptions], [eventsJournalPollingOptions]) ⇒ <code>Observable</code>
-getEventsObservableFromJournal returns an RxJS <a href="https://rxjs-dev.firebaseapp.com/guide/observable">Observable</a>
+getEventsObservableFromJournal returns an RxJS <a href="https://rxjs.dev/guide/observable">Observable</a>
 
-One can go through the extensive documentation on <a href="https://rxjs-dev.firebaseapp.com/guide/overview">RxJS</a> in order to learn more
-and leverage the various <a href="https://rxjs-dev.firebaseapp.com/guide/operators">RxJS Operators</a> to act on emitted events.
+One can go through the extensive documentation on <a href="https://rxjs.dev/guide/overview">RxJS</a> in order to learn more
+and leverage the various <a href="https://rxjs.dev/guide/operators">RxJS Operators</a> to act on emitted events.
 
 **Kind**: instance method of [<code>EventsCoreAPI</code>](#EventsCoreAPI)  
 **Returns**: <code>Observable</code> - observable to which the user can subscribe to in order to listen to events  

--- a/src/index.js
+++ b/src/index.js
@@ -615,10 +615,10 @@ class EventsCoreAPI {
    * @property {number} [interval] Interval at which to poll the journal; If not provided, a default value will be used (optional)
    */
   /**
-   * getEventsObservableFromJournal returns an RxJS <a href="https://rxjs-dev.firebaseapp.com/guide/observable">Observable</a>
+   * getEventsObservableFromJournal returns an RxJS <a href="https://rxjs.dev/guide/observable">Observable</a>
    *
-   * One can go through the extensive documentation on <a href="https://rxjs-dev.firebaseapp.com/guide/overview">RxJS</a> in order to learn more
-   * and leverage the various <a href="https://rxjs-dev.firebaseapp.com/guide/operators">RxJS Operators</a> to act on emitted events.
+   * One can go through the extensive documentation on <a href="https://rxjs.dev/guide/overview">RxJS</a> in order to learn more
+   * and leverage the various <a href="https://rxjs.dev/guide/operators">RxJS Operators</a> to act on emitted events.
    *
    * @param {string} journalUrl URL of the journal or 'next' link to read from (required)
    * @param {EventsJournalOptions} [eventsJournalOptions] Query options to send with the Journal URL

--- a/types.d.ts
+++ b/types.d.ts
@@ -223,10 +223,10 @@ declare class EventsCoreAPI {
      */
     getEventsFromJournal(journalUrl: string, eventsJournalOptions?: EventsJournalOptions, fetchResponseHeaders?: boolean): Promise<object>;
     /**
-     * getEventsObservableFromJournal returns an RxJS <a href="https://rxjs-dev.firebaseapp.com/guide/observable">Observable</a>
+     * getEventsObservableFromJournal returns an RxJS <a href="https://rxjs.dev/guide/observable">Observable</a>
      *
-     * One can go through the extensive documentation on <a href="https://rxjs-dev.firebaseapp.com/guide/overview">RxJS</a> in order to learn more
-     * and leverage the various <a href="https://rxjs-dev.firebaseapp.com/guide/operators">RxJS Operators</a> to act on emitted events.
+     * One can go through the extensive documentation on <a href="https://rxjs.dev/guide/overview">RxJS</a> in order to learn more
+     * and leverage the various <a href="https://rxjs.dev/guide/operators">RxJS Operators</a> to act on emitted events.
      * @param journalUrl - URL of the journal or 'next' link to read from (required)
      * @param [eventsJournalOptions] - Query options to send with the Journal URL
      * @param [eventsJournalPollingOptions] - Journal polling options


### PR DESCRIPTION
## Prism autonomous fix for #32

**Archetype:** typo
**Priority:** P3
**Method:** deterministic find-and-replace

Deterministic find-and-replace: `https://rxjs-dev.firebaseapp.com` → `https://rxjs.dev` (3 files, extracted via expected-actual-urls).

### Files changed
- `README.md` — Replace 3 occurrences of `https://rxjs-dev.firebaseapp.com`
- `src/index.js` — Replace 3 occurrences of `https://rxjs-dev.firebaseapp.com`
- `types.d.ts` — Replace 3 occurrences of `https://rxjs-dev.firebaseapp.com`

> Generated by Prism. Awaiting human review.

Closes #32