### PR TITLE
bump @adobe/aio-lib-state to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@adobe/aio-lib-core-logging": "^3",
     "@adobe/aio-lib-core-networking": "^5",
     "@adobe/aio-lib-env": "^3",
-    "@adobe/aio-lib-state": "^3",
+    "@adobe/aio-lib-state": "^5.3.1",
     "crypto-js": "^4.0.0",
     "http-link-header": "^1.0.2",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
## Description

Bumps `@adobe/aio-lib-state` from `^3` to `^5.3.1`. The v3 release line carried `@azure/cosmos` as a
direct dependency, which pulled in the vulnerable `uuid@8.3.2`. The v5 release line removed `@azure/cosmos`
entirely, breaking the vulnerability chain.

The public API shape used by this library (`init()`, `state.get()`, `state.put()` with no TTL) is unchanged
between v3 and v5 — both return `{ value, expiration }` from `get()`. However, the backend changed from
CosmosDB in v3 to an HTTP-based Adobe I/O service in v5, meaning real validation requires a functional
environment, not unit tests.

## Related Issue

[MWPW-195032](https://jira.corp.adobe.com/browse/MWPW-195032) — CVE-2026-41907 / SNYK-JS-UUID-16133035:
High severity — Improper Validation of Specified Index, Position, or Offset in Input in `uuid`

## Motivation and Context

`uuid@8.3.2` (CVE-2026-41907) is introduced transitively via:

```
@adobe/aio-lib-events → @adobe/aio-lib-state@^3 → @azure/cosmos@3.17.3 → uuid@8.3.2
```

`@adobe/aio-lib-state` v5 removed `@azure/cosmos` entirely. Upgrading eliminates the vulnerable package
from the dependency tree.

## How Has This Been Tested?

Unit tests pass, but are not sufficient to validate this change. `@adobe/aio-lib-state` is fully mocked in the unit
test suite — the mock does not move when the library moves, so unit tests will pass regardless of whether
the v5 library works correctly at runtime.

Real validation requires running the e2e suite (`npm run e2e`) against a live Adobe I/O environment with
valid credentials. This has not been run as part of this PR.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.